### PR TITLE
docs(readme): incluir badge do projeto ServeRest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Cypress - API - Serverest
+
+[![Badge ServeRest](https://img.shields.io/badge/API-ServeRest-green)](https://github.com/ServeRest/ServeRest/)
+
 ## Projeto de exemplo na API Serverest
 
 ### Serverest:


### PR DESCRIPTION
Gostei do seu projeto e da sua iniciativa de criar projeto exemplo com Cypress, está ficando muito bom 😄 
O que acha de adicionar badge do ServeRest no início da documentação?
@fabiocaraujo 